### PR TITLE
Fix invisible white text

### DIFF
--- a/src/components/IssuesSearchInput.vue
+++ b/src/components/IssuesSearchInput.vue
@@ -586,9 +586,6 @@
 
       convert_query(query, use_to_end){
 
-
-        this.color_text(0, query.length, 'white')
-        
         let waits_for_idx = 0 
 
         //query data


### PR DESCRIPTION
This commit removes hardcoded method call which sets color of SearchString content to white. White text then becomes invisible while using light theme.
Before:
![2022-11-18_16h43_01](https://user-images.githubusercontent.com/37111027/202718911-7365ea28-ba33-4007-8a58-62ff1c712c47.png)
![2022-11-18_16h43_13](https://user-images.githubusercontent.com/37111027/202718921-6e6fb02c-eb4d-4c0f-9a68-e7e0ae0a662c.png)

After:

![2022-11-18_16h44_31](https://user-images.githubusercontent.com/37111027/202718937-63e6b9cb-35cb-490a-8372-1700013f5717.png)
