### PR TITLE
Huge layout edits

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -32,9 +32,9 @@ const dict =
 }
 
 app.use(cors());
-app.use(bodyParser.json({limit: '20mb'}));
-app.use(bodyParser.raw({limit: '20mb'}));
-app.use(bodyParser.urlencoded({limit: '20mb', extended: true}));
+app.use(bodyParser.json({limit: '150mb'}));
+app.use(bodyParser.raw({limit: '150mb'}));
+app.use(bodyParser.urlencoded({limit: '150mb', extended: true}));
 
 
 async function notify(issue_uuid, user_uuid)

--- a/src/App.vue
+++ b/src/App.vue
@@ -326,19 +326,6 @@ $loading-bar-width: 200vw;
   margin-right: 20px;
 }
 
-.footer_div {
-  //position: absolute;
-  padding-top: 5px;
-
-  bottom: 0px;
-  //display: table-footer-group;
-}
-
-.footer_div div {
-  display: flex;
-  justify-content: space-between;
-}
-
 .slide-enter-active,
 .slide-leave-active {
   transition: all 0.75s ease-out;
@@ -438,4 +425,29 @@ $loading-bar-width: 200vw;
     text-align: center;
 	padding-top: 4px;
   }
+
+.login-panel .btn_input {
+  margin-top: 10px;
+  width: 100%;
+}
+
+.issue-search-input-btn {
+  padding: 0px;
+  //width: $input-height;
+}
+.issue-search-input-btn .btn_input {
+  padding: 0px;
+  border-top-left-radius: 0px !important;
+  border-bottom-left-radius: 0px !important;
+  margin-left: -$input-height;
+  width: $input-height !important;
+  height: $input-height;
+
+  border-top-width: var(--issue-search-btn-top-border-width) !important;
+  border-bottom-width: var(--border-width) !important;
+  border-left-color: var(--border-color) !important;
+  border-top-color: var(--border-color) !important;
+  //border-bottom-color: $border-color !important;
+}
+
 </style>

--- a/src/components/EditTagModal.vue
+++ b/src/components/EditTagModal.vue
@@ -102,7 +102,7 @@ export default {
   top: $top-menu-height;
 }
 
-.edit-tag-modal > div {
+.edit-tag-modal > *:not(:last-child) {
   margin-bottom: 10px;
 }
 

--- a/src/components/IssuesSearchInput.vue
+++ b/src/components/IssuesSearchInput.vue
@@ -161,7 +161,10 @@ export default {
         html +=
           '<span class="issues-search-char char-' +
           i +
-          '">' +
+          '" style="  margin: 0 !important;\n' +
+            '  font-size: 15px !important;\n' +
+            '  margin-top: 5px !important;">' +
+          "" +
           chars[i] +
           "</span>";
       }
@@ -720,7 +723,7 @@ export default {
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import "../css/global.scss";
 
 .issue-search-div .text-input {
@@ -731,12 +734,6 @@ export default {
   margin-right: 30px !important;
 }
 
-.issues-search-char {
-  margin: 0px !important;
-  font-size: 15px !important;
-  margin-top: 5px !important;
-}
-
 .text .text-input {
   width: 100%;
   height: $input-height;
@@ -744,9 +741,6 @@ export default {
   color: var(--text-color);
   padding: 0 10px 0 10px;
   resize: none;
-}
-
-.text {
 }
 
 .text-input {
@@ -823,21 +817,5 @@ export default {
   padding: 0px !important;
   width: 50vw;
 }
-.issue-search-input-btn {
-  padding: 0px;
-  //width: $input-height;
-}
-.issue-search-input-btn .btn_input {
-  padding: 0px;
-  border-top-left-radius: 0px !important;
-  border-bottom-left-radius: 0px !important;
-  margin-left: -$input-height;
-  width: $input-height !important;
 
-  border-top-width: var(--issue-search-btn-top-border-width) !important;
-  border-bottom-width: var(--border-width) !important;
-  border-left-color: var(--border-color) !important;
-  border-top-color: var(--border-color) !important;
-  //border-bottom-color: $border-color !important;
-}
 </style>

--- a/src/components/KAttachment.vue
+++ b/src/components/KAttachment.vue
@@ -166,6 +166,7 @@ $attachment_input_border_width: 2px;
 }
 
 .attachment-input {
+  min-height: 86px;
   font-size: 20px;
   font-weight: 400;
   border-radius: var(--border-radius);

--- a/src/components/KMarked.vue
+++ b/src/components/KMarked.vue
@@ -216,7 +216,7 @@ a {
   width: 100%;
   color: var(--text-color);
   font-family: Inter, system-ui, Roboto, sans-serif;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .marked-container p:first-child {
@@ -229,6 +229,10 @@ a {
 
 .marked-container::-webkit-scrollbar {
   display: none;
+}
+
+.marked-container a:hover {
+  color: var(--link-hover-color);
 }
 
 .marked-container img {
@@ -267,7 +271,7 @@ a {
   border-radius: 4px;
   background-color: var(--code-block-bg-color);
   border: 10px solid transparent;
-  max-height: 400px;
+  max-height: 300px;
   max-width: -webkit-fill-available;
   overflow: auto;
   padding: 10px;
@@ -330,6 +334,12 @@ a {
 
 .marked-container dl {
   padding-left: 20px;
+}
+
+.marked-container blockquote {
+  margin: 4px 0;
+  padding: 0 0 0 16px;
+  box-shadow: inset 2px 0 0;
 }
 
 .marked-container * {

--- a/src/components/KNewRelationModal.vue
+++ b/src/components/KNewRelationModal.vue
@@ -152,7 +152,7 @@ export default {
   transform: translate(-50%, -50%);
 }
 
-.new-relation-modal > div {
+.new-relation-modal > *:not(:last-child) {
   margin-bottom: 10px;
 }
 

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -175,11 +175,8 @@ export default {
   flex-direction: column;
 }
 
-#profile-menu > div {
+#profile-menu > *:not(:last-child) {
   margin-bottom: 10px;
-}
-
-#profile-menu .select-input {
 }
 
 #profile-menu-exit {

--- a/src/components/SelectInput.vue
+++ b/src/components/SelectInput.vue
@@ -230,8 +230,9 @@ export default {
           class="vs__selected">
             {{ option.name }}
           </span>
-          
-          <i class='bx bx-x' @click="deselect(option)"></i>
+          <div class="x-icon-container">
+            <i class='bx bx-x' @click="deselect(option)"></i>
+          </div>
         </div>
       </template>
       <template v-slot:no-options="{ searching }">
@@ -265,13 +266,6 @@ export default {
 .select-input .vs__clear,
 .select-input .vs__open-indicator {
   fill: var(--text-color);
-}
-
-
-.select-input-selected
-{
-  font-weight: 700;
-  margin-right: 10px;
 }
 
 .vs__active {
@@ -314,10 +308,12 @@ export default {
 }
 
 .select-input-selected{
+  font-weight: 700;
+  margin-right: 10px;
   background-color: var(--table-row-color-selected);
   border-radius: var(--border-radius);
   display: flex;
-
+  align-items: center;
 }
 
 .vs__deselect {

--- a/src/components/TagInput.vue
+++ b/src/components/TagInput.vue
@@ -111,28 +111,41 @@ export default {
 }
 
 .tag-input .vs__dropdown-toggle{
+  display: flex;
+  align-items: center;
   background: none;
   border: none;
+  padding: 0;
 }
 
 .tag-input .vs__selected{
-  margin: 0;
-    padding-top: 0;
+  margin: 0 0 0 5px;
+  padding-top: 0;
   background: none;
   cursor: pointer;
   border: none;
 }
+
+.tag-input .vs__search {
+  margin: 0;
+}
+
+.tag-input .select-input-selected {
+  margin-right: 5px !important;
+  height: 23px;
+}
+
+.tag-input .vs__selected-options {
+  display: flex;
+  align-items: center;
+}
+
 
 .tag-input i{
   margin-top: 4px;
     font-size: 20px;
     cursor: pointer;
 }
-
-
-
-
-
 
 .tag-input .vs__search:hover,
  .tag-input .vs__search:focus,
@@ -146,8 +159,5 @@ export default {
     border-width: var(--border-width) !important;
     border-radius: var(--border-radius) !important;
 }
-
-
-
 
 </style>

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -46,11 +46,8 @@ export default {
     resize() {
       console.log("resizing");
       if (this.$refs.text_input == undefined) return;
-      //this.$refs.text_input.style.height = "auto";
-      //this.$refs.text_input.style.height = 0
-
       this.$refs.text_input.style.height = `${
-        this.$refs.text_input_shadow.scrollHeight + 4
+        this.$refs.text_input_shadow.scrollHeight + 10
       }px`;
     },
     getCaretIndex(element) {
@@ -106,18 +103,18 @@ export default {
       this.resize();
     })
   },
-  computed: {
+  /*computed: {
     scroll_height: function () {
       if (this.$refs == undefined || this.$refs.text_input_shadow == undefined)
         return 0;
       return this.$refs.text_input_shadow.scrollHeight;
     },
-  },
+  },*/
 
   watch: {
-    scroll_height: function () {
+    /*scroll_height: function () {
       this.resize();
-    },
+    },*/
     value: function (val, oldVal) {
       if (this.val == val) return;
       this.val = val;
@@ -172,7 +169,7 @@ export default {
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import "../css/global.scss";
 
 .text .text-input {
@@ -184,20 +181,16 @@ export default {
   resize: none;
 }
 
-.text {
-}
-
 .text-input {
-  font-size: 13px;
-  font-weight: 400;
-  border-radius: var(--border-radius);
-  background: var(--input-bg-color);
   width: 100%;
-
+  font-size: 14px;
+  font-weight: 400;
+  background: var(--input-bg-color);
   border-color: var(--border-color);
-  border-style: inset;
+  border-style: var(--border-style);
   border-width: var(--border-width);
   border-radius: var(--border-radius);
+  overflow: clip;
 }
 
 .text-input-shadow {

--- a/src/components/TopMenu.vue
+++ b/src/components/TopMenu.vue
@@ -46,9 +46,7 @@ export default {
         max-height: calc(100% - 60px);
       "
     >
-      <span>
-        {{ label }}
-      </span>
+      <span class="topbar-label">{{ label }}</span>
       <SearchInput :name="name" :collumns="collumns" />
 
       <KButton
@@ -105,7 +103,7 @@ export default {
   background: var(--input-bg-color);
 }
 
-.topbar span {
+.topbar-label {
   font-size: 20px;
   font-weight: 400;
   margin-top: 1px;
@@ -120,8 +118,6 @@ export default {
   margin-left: 20px;
   margin-right: 10px;
 }
-
-
 
 @media (max-width: 420px) {
   .topbar li .tooltip {

--- a/src/components/WorkflowsEditor.vue
+++ b/src/components/WorkflowsEditor.vue
@@ -519,7 +519,7 @@ export default {
   height: 60px;
 }
 
-.workflows-command-panel > div {
+.workflows-command-panel > *:not(:last-child) {
   margin-right: 20px;
 }
 

--- a/src/css/palette.scss
+++ b/src/css/palette.scss
@@ -60,6 +60,8 @@
 
     --scroll-color: rgb(70, 70, 70);
     --scroll-shadow-color: rgb(10,10,10);
+
+    --link-hover-color: green;
 }
 [theme="light"]
 {
@@ -122,6 +124,8 @@
 
     --scroll-color: rgb(235, 246, 255);
     --scroll-shadow-color: rgb(165,176,185);
+
+    --link-hover-color: green;
 }
 [theme="dark"]
 {
@@ -185,6 +189,8 @@
 
     --scroll-color: rgb(65, 70, 73);
     --scroll-shadow-color: rgb(10,15,20);
+
+    --link-hover-color: green;
 }
 [theme="pink"]
 {
@@ -246,4 +252,6 @@
 
     --scroll-color: rgb(245, 150, 205);
     --scroll-shadow-color: rgb(205,110,165);
+
+    --link-hover-color: green;
 }

--- a/src/gadgets/IssuesTable.vue
+++ b/src/gadgets/IssuesTable.vue
@@ -6,8 +6,6 @@ import d from "../dict.ts";
 import rest from "../rest";
 import tools from "../tools.ts";
 
-console.log("d", d.get("Название"), d);
-
 let methods = {
   add_with_children: function (obj, arr, ch_level) {
     if (ch_level > 10) return arr;
@@ -258,7 +256,7 @@ export default mod;
           max-height: calc(100% - 60px);
         "
       >
-        <span>{{ label }}</span>
+        <span class="topbar-label">{{ label }}</span>
 
         <IssuesSearchInput
           label=""

--- a/src/page_helper.ts
+++ b/src/page_helper.ts
@@ -218,7 +218,7 @@ page_helper.create_module = async function (data, methods) {
   methods.init_part2 = function (params) {
     for (const i in this.inputs) {
       const name = this.inputs[i].dictionary;
-      console.log(name);
+      //console.log(name);
       if (name == undefined) continue;
       if (this.$store.state[name][name + "_updated"] == undefined) {
         setTimeout(this.init_part2, 50, params);

--- a/src/views/PageBoard.vue
+++ b/src/views/PageBoard.vue
@@ -1,14 +1,10 @@
 <script>
-	
 	import page_helper from '../page_helper.ts'
 	import query_parser from '../query_parser.ts'
 
 	import d from '../dict.ts'
 	import rest from '../rest';
 	import tools from '../tools.ts'
-	import { computed } from '@vue/runtime-core';
-
-
 
 	let methods = {
 		get_favourite_uuid() {
@@ -766,8 +762,6 @@
 
   mod.computed.board_query_info = function(){
 	  let board_query_info = this.search_query
-	  
-
 
 	return board_query_info
   }
@@ -788,17 +782,15 @@
 	return values
   }
 
-  mod.computed.swimlanes_value = function()
-  {
-	if(this.selected_board == undefined) return null
-	if(this.selected_board.no_swimlanes) return null
-	if(this.selected_board.swimlanes_by_root) return '0'
-	else return this.selected_board.swimlanes_field_uuid
+  mod.computed.swimlanes_value = function() {
+    if(this.selected_board == undefined) return null
+    if(this.selected_board.no_swimlanes) return null
+    if(this.selected_board.swimlanes_by_root) return '0'
+    else return this.selected_board.swimlanes_field_uuid
   }
 
 
-  mod.computed.total_count = function()
-  {
+  mod.computed.total_count = function() {
 	  let count = 0
   	for(let i in this.swimlanes)
 	  {
@@ -807,8 +799,7 @@
 	  return count
   }
 
-  mod.computed.total_sum = function()
-  {
+  mod.computed.total_sum = function() {
 	  let sum = 0
   	for(let i in this.swimlanes)
 	  {
@@ -817,12 +808,7 @@
 	  return sum
   }
 
- 
-
-  
-
-  mod.props =
-    {
+  mod.props = {
       uuid:
       {
         type: String,
@@ -830,17 +816,9 @@
       }
     }
 
-
-	
-   
-  
-  
-
 	export default mod
 	
 </script>
-
-
 
 <template ref='board' >
 <div @mouseup="dragend_card()">
@@ -1101,18 +1079,18 @@
 		></SelectInput>
 
 	
-		<div class="btn-container">
-		<KButton 
-		name="Сохранить"
-		id="save-board-config-btn"
-		:func="'save_board'"
-		@click="configs_open=false"
-		/>
-		<KButton 
-		name="Отменить"
-		id="cancel-board-config-btn"
-		@click="configs_open=false"
-		/>
+		<div class="table_card_footer">
+      <KButton
+        name="Сохранить"
+        class="table_card_footer_btn"
+        :func="'save_board'"
+        @click="configs_open=false"
+      />
+      <KButton
+        name="Отменить"
+        class="table_card_footer_btn"
+        @click="configs_open=false"
+      />
 		</div>
 
 		</div>
@@ -1124,9 +1102,6 @@
 
 	</div>
 </template>
-
-
-
 
 <style lang="scss">
   @import '../css/palette.scss';
@@ -1153,15 +1128,37 @@
   }
 
   #board_down_panel {
+    padding-right: 7px;
     display: flex;
-	flex-direction: column;
-	height: calc(100vh - $top-menu-height);
-
-	overflow:scroll;
+	  flex-direction: column;
+	  height: calc(100vh - $top-menu-height);
+	  overflow:scroll;
   }
 
   #board_down_panel::-webkit-scrollbar{
     display:none;
+  }
+
+  .board-config {
+    padding: 20px;
+  }
+
+  .board-config > *:not(:last-child) {
+    margin-bottom: 10px;
+  }
+
+  .table_card_footer {
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .table_card_footer_btn {
+    width: 45%;
+
+    input {
+      width: 100%;
+    }
   }
 
 
@@ -1294,15 +1291,6 @@
 		-ms-user-select: none;
   }
 
-  #save-board-config-btn
-  {
-	  padding-right: 10px;
-  }
-  #cancel-board-config-btn
-  {
-	  padding-left: 10px;
-  }
-
   .top-menu-icon-btn {
 	  height: 35px;
     font-size: 25px;
@@ -1320,20 +1308,13 @@
 	padding-top: 4px;
   }
 
-  .delete-board-btn
-  {
+  .delete-board-btn {
 	font-size: 23px;
 	padding-top: 5px;
 	color: #d27065
   }
 
-  
-  .board-issue-search-input
-  {
-	padding: 10px 20px 10px 20px !important;
-  }
-
-  .board-issue-search-input span {
+  .panel topbar span {
     font-size: 20px;
     font-weight: 400;
     margin-top: 1px;
@@ -1368,8 +1349,10 @@
 	width: $font-size;
 	height: $input-height;
 	border-radius: var(--border-radius);
-	margin: 0px !important;
-	padding-top: 3px;
+	margin: 0 0 0 2px !important;
+	padding-top: 0px;
+  font-size: 20px;
+  font-weight: 400;
 }
 
 .board-sprint-filter-btn:hover{

--- a/src/views/PageIssues.vue
+++ b/src/views/PageIssues.vue
@@ -6,8 +6,6 @@ import d from "../dict.ts";
 import rest from "../rest";
 import tools from "../tools.ts";
 
-console.log("d", d.get("Название"), d);
-
 let methods = {
   add_with_children: function (obj, arr, ch_level) {
     if (ch_level > 10) return arr;
@@ -19,7 +17,6 @@ let methods = {
     if (obj.children == undefined) return arr;
 
     for (let i in obj.children) {
-      console.log(obj, ch_level);
       arr = this.add_with_children(obj.children[i], arr, ch_level + 1);
     }
 
@@ -51,8 +48,6 @@ let methods = {
 
     let issues = await rest.run_method("read_issues", options);
 
-    console.log("this.loaded_issues0", issues);
-
     if (offset != undefined) {
       for (let i in issues) {
         this.loaded_issues.push(issues[i]);
@@ -81,8 +76,6 @@ let methods = {
       }
     }
 
-    console.log("this.loaded_issues0", this.loaded_issues);
-
     this.loaded_issues_tree = [];
 
     for (let i in this.loaded_issues) {
@@ -94,11 +87,11 @@ let methods = {
         );
     }
 
-    console.log(
+   /* console.log(
       "this.loaded_issues1",
       this.loaded_issues,
       this.loaded_issues_tree
-    );
+    );*/
 
     //this.loaded_issues = issues
     //console.log(this.loaded_issues[0], this.issues[0])
@@ -286,7 +279,7 @@ export default mod;
           max-height: calc(100% - 60px);
         "
       >
-        <span>{{ label }}</span>
+        <span class="topbar-label">{{ label }}</span>
 
         <IssuesSearchInput
           label=""
@@ -313,7 +306,7 @@ export default mod;
           @click="tree_view = !tree_view"
         ></i>
         <i class="bx bx-star top-menu-icon-btn" @click="add_to_favourites"> </i>
-        <span>{{loaded_issues.length}}/{{total_count}}</span>
+        <span class="topbar-label">{{loaded_issues.length}}/{{total_count}}</span>
       </div>
     </div>
 

--- a/src/views/PageIssues.vue
+++ b/src/views/PageIssues.vue
@@ -326,12 +326,12 @@ export default mod;
           @click="tree_view = !tree_view"
         ></i>
         <i class="bx bx-star top-menu-icon-btn" @click="add_to_favourites"> </i>
-        <i v-if="!loading" class="topbar-label bx bxs-download top-menu-icon-btn"
+        <i v-if="!loading" class="bx bxs-download top-menu-icon-btn"
         @click="get_excel"
         > </i>
 
 
-        <span>{{loaded_issues.length}}/{{total_count}}</span>
+        <span class="topbar-label">{{loaded_issues.length}}/{{total_count}}</span>
       </div>
     </div>
 

--- a/src/views/PageLogin.vue
+++ b/src/views/PageLogin.vue
@@ -74,8 +74,9 @@ export default login_page;
 @import "../css/global.scss";
 
 .login-panel {
-  height: 250px;
-  width: 400px;
+  padding: 20px;
+  height: 230px;
+  width: 350px;
   position: absolute;
   left: calc(50vw - $main-menu-width/2);
   top: 40vh;
@@ -86,8 +87,8 @@ export default login_page;
   width: 250px;
 }
 
-.login-panel .btn {
-  padding: 30px 20px 10px 20px;
+.login-panel > *:not(:last-child) {
+  margin-bottom: 10px;
 }
 
 .login-panel .btn Input {

--- a/src/views/css/_table-page.scss
+++ b/src/views/css/_table-page.scss
@@ -21,12 +21,8 @@ $table-card-width: calc(100% - $table-panel-width);
   width: $table-card-width;
   display: inline-block;
 }
-.table_card > div {
-  margin-bottom: 20px;
-}
 
-//TODO remove this when boolean is changed to div
-.table_card > .boolean {
+.table_card > *:not(:last-child) {
   margin-bottom: 20px;
 }
 


### PR DESCRIPTION
Рефакторинг
- Улучшенное хранение дочерних элементов `div > *:not(:last-child)`
- Убрать пересечение .text .text-input стилей от TextInput и IssuesSearchInput в scoped
- Поправить span в строке поиска (scoped) - так же пересекались стили
-  Убран спам логов

Борды
- Добавить отступы в редакторе борд
- Поправить кнопку поиска в редакторе борд
- Небольшие правки отступов

Экран логина
- Добавить отступы на экране логина

Теги
- Поправить высоту тегов  (слишком жирные)
- Поправить отступы

Маркдаун
- Выровнять шрифт эдита и отображаемый в чистовике шрифт (14px) (+ к единообразию)
- Ховер на ссылки в маркдауне сделать таким же как в связанных задачах
- Добавить стили для цитирования <blockquote>
- Сузить `max height` в pre code (`400px` ->` 300px`) - слишком широкий

Задача
- Передвинуть title в задаче
- Поправить различные отступы в хедере задачи
- Починить некорректное заполнение полей в черновике (invalid-undefined)
- Положение кнопки "Сохранить" в черновике - передвинуть из карточки под описание (+ к единообразию)
- Превью маркдауна в черновике задачи
- Отступ над превью маркдауна в режиме редактирования

Задачи и комменты (important!)
- Увеличить размеры дефолтного поля для ввода (+1 строка)
- Убрать прыжки эдита (transition), особенно заметно при вставке
- Никакого скролла внутри эдита!
- Поправить динамическое изменение размера поля с описанием