### PR TITLE
Fix md panel shortcuts, fix edit history

### DIFF
--- a/src/components/KMarkdownInput.vue
+++ b/src/components/KMarkdownInput.vue
@@ -30,7 +30,7 @@ export default {
       default: "",
     },
   },
-  emits: ["update_parent_from_input"],
+  emits: ["update_parent_from_input", "input_focus"],
   methods: {
     resize() {
       let element = this.$refs["markdown-textarea-resizable"];
@@ -311,9 +311,12 @@ export default {
             :placeholder="placeholder"
             @input="resize"
             @keydown ="keyEvent"
+            @focus="$emit('input_focus', true)"
+            @blur="$emit('input_focus', false)"
         ></textarea>
       </div>
     </div>
+
   </Transition>
 </template>
 
@@ -369,6 +372,10 @@ export default {
 .md-preview {
   display: inline-block;
   align-self: flex-end;
+}
+
+.markdown-input:focus-within {
+  outline: 1px solid;
 }
 
 </style>

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -68,29 +68,6 @@ export default {
       }
       return position;
     },
-    make_bold(e) {
-      const bold_tag = "**";
-      console.log("make_bold", e.target);
-      // console.log(e)
-      var elInput = e.target; //document.getElementById('tempid') // Select the object according to the id selector
-      var startPos = elInput.selectionStart; // input the 0th character to the selected character
-      var endPos = elInput.selectionEnd; // The selected character to the last character
-
-      if (startPos < endPos) {
-        //console.log(e, startPos, endPos)
-        this.val =
-          this.val.substring(0, startPos) +
-          bold_tag +
-          this.val.substring(startPos, endPos) +
-          bold_tag +
-          this.val.substring(endPos);
-
-        nextTick(() => {
-          elInput.selectionStart = endPos + bold_tag.length * 2;
-          elInput.selectionEnd = endPos + bold_tag.length * 2;
-        });
-      }
-    },
     pasted(e) {
       console.log(e);
     },
@@ -153,7 +130,6 @@ export default {
       ref="text_input"
       @focus="$emit('input_focus', true)"
       @blur="$emit('input_focus', false)"
-      @keydown.ctrl.b="make_bold"
       :id="textarea_id"
       class="text-input"
       :type="type"

--- a/src/views/PageIssue.vue
+++ b/src/views/PageIssue.vue
@@ -1167,20 +1167,22 @@ export default mod;
             :id="'values.' + get_field_by_name('Описание').idx + '.value'"
             @update_parent_from_input="update_comment"
             @paste="pasted"
+            @input_focus="comment_focus"
             placeholder="Комментарий к задаче..."
             textarea_id="issue_comment_textarea"
             transition="element_fade"
           />
         <Transition name="element_fade">
           <KButton
-            v-if="!loading && !edit_mode && id !== ''"
-            id="send_comment_btn"
-            name="Отправить"
-            v-bind:class="{ outlined: comment_focused }"
-            @click="send_comment()"
-            :disabled="comment === ''"
+              v-if="!loading && !edit_mode && id !== ''"
+              id="send_comment_btn"
+              name="Отправить"
+              v-bind:class="{ outlined: comment_focused }"
+              @click="send_comment()"
+              :disabled="comment === ''"
           />
         </Transition>
+
 
         <CommentList
             v-if="!loading && !edit_mode"

--- a/src/views/PageIssue.vue
+++ b/src/views/PageIssue.vue
@@ -33,25 +33,8 @@ let methods = {
             type: file.type,
             table_name: "attachments",
           };
-
-          let start_pos = e.target.selectionStart;
-
           let img_teg = '![](' + attachment.name + "." + attachment.extention + '){width=x%}';
-
-          if (e.target.id == "issue_description_textarea") {
-            let f = this.get_field_by_name("Описание");
-            f.value =
-              this.current_description.substring(0, start_pos) +
-              img_teg +
-              this.current_description.substring(start_pos);
-          } else {
-            this.comment =
-              this.comment.substring(0, start_pos) +
-              img_teg +
-              this.comment.substring(start_pos);
-             //console.log(this.comment)
-          }
-
+          document.execCommand('insertText', false, img_teg)
           this.add_attachment(attachment);
         } else {
           return;


### PR DESCRIPTION
- Исправлено проблема со сбросом истории изменений, когда вызываются методы маркдаун-панели.
- Исправлена аналогичная проблема со вставкой картинки из буфера
- Поправлены сочетания клавиш, теперь работает на любой раскладке
- (WIP, элемент скрыт) добавлена кнопка превью маркдауна