### PR TITLE
Cache (localStorage wrapper)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@ import KAlerter from "./components/KAlerter.vue";
 import palette from "./palette.ts";
 import dict from "./dict.ts";
 import tools from "./tools.ts";
+import cache from "./cache.ts";
 
 let uri = window.location.href;
 
@@ -21,7 +22,6 @@ export default {
 
   created() {
     this.check_is_in_workspace();
-    // console.log('localStorage.tic', localStorage.tic)
     /*
       let uri = window.location.href
      
@@ -37,9 +37,9 @@ export default {
 
   mounted() {
     console.log("app mounted");
-    if (localStorage.theme == undefined) localStorage.theme = "dark";
+    let theme = cache.getString('theme')
     let htmlElement = document.documentElement;
-    htmlElement.setAttribute("theme", localStorage.theme);
+    htmlElement.setAttribute("theme", theme);
 
     this.$store.state["common"]["is_mobile"] = this.is_mobile() || this.in_iframe();
     this.$store.state["common"]["in_iframe"] = this.in_iframe();

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,66 @@
+// LocalStorage wrapper
+export default class cache {
+
+  static defaultSettings: Map<string, string> = new Map ([
+    ['theme',                    "dark"  ],
+    ['issues_query',             ""      ],
+    ['lock_main_menu',           "false" ],
+    ['actions_sort_order',       "true"  ],
+    ['actions_show_comments',    "true"  ],
+    ['actions_show_time',        "true"  ],
+    ['actions_show_edits',       "true"  ],
+    ['actions_show_transitions', "true"  ],
+  ])
+
+  static clear() {
+    localStorage.clear()
+  }
+
+  // Get object from localStorage
+  static getObject(settingName: string) : any {
+    return this.get(settingName, true)
+  }
+
+  // Get string from localStorage
+  static getString(settingName: string) : string {
+    return this.get(settingName, false)
+  }
+
+  // Write object to localStorage as JSON string
+  static setObject(settingName: string, object: any) {
+    localStorage.setItem(settingName, object)
+  }
+
+  // Write string to localStorage
+  static setString(settingName: string, object: string) {
+    localStorage.setItem(settingName, JSON.stringify(object))
+  }
+
+  // Get value from localStorage or return and save default value if none is set.
+  private static get(settingName: string, asObject: boolean) : any {
+    const storageValue = localStorage.getItem(settingName)
+    if (storageValue !== undefined) {
+      if (storageValue !== null) {
+        if (asObject) {
+          return JSON.parse(storageValue)
+        } else {
+          return storageValue
+        }
+      }
+    } else {
+      // return default value and add default value to localStorage
+      const defaultSetting = this.defaultSettings.get(settingName)
+      if (defaultSetting !== undefined) {
+        if (asObject) {
+          localStorage.setItem(settingName, JSON.parse(defaultSetting))
+          return JSON.parse(defaultSetting)
+        } else {
+          localStorage.setItem(settingName, defaultSetting)
+          return defaultSetting
+        }
+      }
+    }
+    return undefined
+  }
+}
+

--- a/src/components/CommentList.vue
+++ b/src/components/CommentList.vue
@@ -48,15 +48,16 @@
 </template>
 
 <script>
+import cache from "../cache.ts";
 export default {
   name: "CommentList",
   data() {
     return {
-      showComments: true,
-      showTime: true,
-      showEdits: true,
-      showTransitions: true,
-      sortOrder: true,
+      showComments:    cache.getObject("actions_sort_order"),
+      showTime:        cache.getObject("actions_show_time"),
+      showEdits:       cache.getObject("actions_show_edits"),
+      showTransitions: cache.getObject("actions_show_transitions"),
+      sortOrder:       cache.getObject("actions_sort_order"),
     };
   },
   props: {
@@ -101,66 +102,25 @@ export default {
   },
   methods: {
     invertSortOrder() {
-      localStorage.actions_sort_order = !this.sortOrder;
+      cache.setObject('actions_sort_order', !this.sortOrder);
       this.sortOrder = !this.sortOrder;
     },
     toggleComments() {
-      localStorage.actions_show_comments = !this.showComments;
+      cache.setObject('actions_show_comments', !this.showComments);
       this.showComments = !this.showComments;
     },
     toggleTime() {
-      localStorage.actions_show_time = !this.showTime;
+      cache.setObject('actions_show_time', !this.showTime);
       this.showTime = !this.showTime;
     },
     toggleEdits() {
-      localStorage.actions_show_edits = !this.showEdits;
+      cache.setObject('actions_show_edits', !this.showEdits);
       this.showEdits = !this.showEdits;
     },
     toggleTransitions() {
-      localStorage.actions_show_transitions = !this.showTransitions;
+      cache.setObject('actions_show_transitions', !this.showTransitions);
       this.showTransitions = !this.showTransitions;
     },
-  },
-  mounted() {
-    const sortOrder = localStorage.actions_sort_order;
-    if (sortOrder !== undefined) {
-      this.sortOrder = JSON.parse(sortOrder);
-    } else {
-      localStorage.actions_sort_order = true;
-      this.sortOrder = true;
-    }
-
-    const showComments = localStorage.actions_show_comments;
-    if (showComments !== undefined) {
-      this.showComments = JSON.parse(showComments);
-    } else {
-      localStorage.actions_show_comments = true;
-      this.showComments = true;
-    }
-
-    const showTime = localStorage.actions_show_time;
-    if (showTime !== undefined) {
-      this.showTime = JSON.parse(showTime);
-    } else {
-      localStorage.actions_show_time = true;
-      this.showTime = true;
-    }
-
-    const showEdits = localStorage.actions_show_edits;
-    if (showEdits !== undefined) {
-      this.showEdits = JSON.parse(showEdits);
-    } else {
-      localStorage.actions_show_edits = true;
-      this.showEdits = true;
-    }
-
-    const showTransitions = localStorage.actions_show_transitions;
-    if (showTransitions !== undefined) {
-      this.showTransitions = JSON.parse(showTransitions);
-    } else {
-      localStorage.actions_show_transitions = true;
-      this.showTransitions = true;
-    }
   },
 };
 </script>

--- a/src/components/KAlerter.vue
+++ b/src/components/KAlerter.vue
@@ -49,7 +49,6 @@ export default {
     }
     //console.log('alalaaaa', this.alerts)
     //console.log('uuuuu')
-    // this.user = JSON.parse(localStorage.profile)
   },
 };
 </script>

--- a/src/components/KMarkdownInput.vue
+++ b/src/components/KMarkdownInput.vue
@@ -29,16 +29,20 @@ export default {
       type: String,
       default: "",
     },
+    parent_name: {
+      type: String,
+      default: "",
+    },
   },
   emits: ["update_parent_from_input", "input_focus"],
   methods: {
     resize() {
-      let element = this.$refs["markdown-textarea-resizable"];
+      let element = this.$refs["markdown_textarea_resizable"];
       element.style.height = "66px";
       element.style.height = element.scrollHeight + "px";
     },
     getSelectionVars() {
-      let textArea = this.$refs["markdown-textarea-resizable"]
+      let textArea = this.$refs["markdown_textarea_resizable"]
       let startPos = textArea.selectionStart
       let endPos = textArea.selectionEnd
       return {textArea, startPos, endPos}
@@ -131,7 +135,7 @@ export default {
       });
     },
     keyEvent(event) {
-      console.log('keyCode: ',event.keyCode,', event:', event)
+      //console.log('keyCode: ',event.keyCode,', event:', event)
       if (event.ctrlKey) {
         if (!event.shiftKey) { // Ctrl
           switch (event.keyCode) {
@@ -246,6 +250,7 @@ export default {
   },
   watch: {
     value(val) {
+      if (this.val === val) return;
       this.val = val;
     },
     val(val) {
@@ -304,7 +309,7 @@ export default {
       </div>
       <div class="markdown-input-container">
         <textarea
-            ref="markdown-textarea-resizable"
+            ref="markdown_textarea_resizable"
             class="markdown-input-textarea"
             v-model="val"
             :id="textarea_id"

--- a/src/components/KMarked.vue
+++ b/src/components/KMarked.vue
@@ -103,7 +103,7 @@ export default {
 
       //console.log(html)
       this.wait_for_recalc_count--;
-      console.log('recalced')
+      //console.log('recalced')
       return new_html
     },
 

--- a/src/components/KMarked.vue
+++ b/src/components/KMarked.vue
@@ -1,8 +1,9 @@
 <script>
-import tools from "../tools.ts";
 import { marked } from "marked";
-import palette from "../css/palette.scss?type=style&index=0&lang=scss&module=1";
 import { nextTick } from "vue";
+import tools from "../tools.ts";
+import palette from "../css/palette.scss?type=style&index=0&lang=scss&module=1";
+import cache from "../cache.ts";
 
 export default {
   
@@ -26,7 +27,7 @@ export default {
   },
   methods: {
     get_palette_param: function (name) {
-      let theme = "[theme=" + localStorage.theme + "]";
+      let theme = "[theme=" + cache.getString("theme") + "]";
       let val = palette.split(theme);
       val = val[1];
       val = val.split(name + ": ");
@@ -162,9 +163,9 @@ export default {
   },
   images: {
     handler: function (val, oldVal) {
-        this.val.toString()
-      console.log('viiim', val, oldVal)
-     // this.md_value = this.md(this.val);
+      this.val.toString()
+      // console.log('viiim', val, oldVal)
+      // this.md_value = this.md(this.val);
     },
     deep: true,
       immediate: true

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -1,6 +1,7 @@
 <script>
 import dict from "../dict.ts";
 import tools from "../tools.ts";
+import cache from "../cache";
 
 export default {
   props: {
@@ -131,7 +132,7 @@ export default {
   methods: {
     move_hover(e) {
       if (this.$store.state["common"]["is_mobile"]) return;
-      if (localStorage.lock_main_menu != "true") this.is_opened = true;
+      if (cache.getObject("lock_main_menu") !== true) this.is_opened = true;
       this.hover_opacity = 1;
       this.hover_offset_x = e.target.offsetLeft;
       this.hover_offset_y = e.target.offsetTop;

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -1,4 +1,5 @@
 <script>
+import cache from "../cache";
 export default {
   data() {
     return {
@@ -18,32 +19,25 @@ export default {
     };
   },
   mounted() {
-    console.log("localStorage.profile", localStorage.profile);
-
+    console.log("Cached profile:", cache.getObject('profile'));
     for (let i = 0; i < this.themes.length; i++) {
-      if (localStorage.theme == this.themes[i].val) this.theme = this.themes[i];
+      if (cache.getString("theme") === this.themes[i].val) this.theme = this.themes[i];
     }
-
-    if (localStorage.lock_main_menu == "true") this.lock_main_menu = true;
-
-    //console.log(this.user.avatar)
-
+    this.lock_main_menu = cache.getObject("lock_main_menu");
     document.addEventListener("click", this.close_menu);
 
     try {
-      this.user = JSON.parse(localStorage.profile);
+      this.user = cache.getObject("profile");
     } catch (err) {}
   },
   updated() {
     //console.log('uuuuu')
-    //this.user = JSON.parse(localStorage.profile)
   },
 
   methods: {
     logout() {
-      //console.log('logout')
-      localStorage.user_token = "";
-      localStorage.profile = "{}";
+      cache.setString("user_token", "");
+      cache.setObject("profile", {});
       this.$router.push("/login");
     },
     close_menu(e) {
@@ -55,13 +49,13 @@ export default {
     },
     set_theme(theme) {
       this.theme = theme;
-      localStorage.theme = theme.val;
+      cache.setString("theme", theme.val)
       let htmlElement = document.documentElement;
       htmlElement.setAttribute("theme", theme.val);
     },
     set_lang(lang) {},
     update_lock_main_menu(value) {
-      localStorage.lock_main_menu = value + "";
+      cache.setObject("lock_main_menu", value)
     },
   },
 };

--- a/src/components/StringInput.vue
+++ b/src/components/StringInput.vue
@@ -31,7 +31,7 @@ export default {
 
   watch: {
     value: function (val, oldVal) {
-      console.log(val, oldVal, this.id, this.parent_name);
+      //console.log(val, oldVal, this.id, this.parent_name);
 
       this.$emit("update_parent_from_input", val);
 

--- a/src/components/UserInput.vue
+++ b/src/components/UserInput.vue
@@ -4,6 +4,7 @@ import store_helper from "../store_helper.ts";
 import tools from "../tools.ts";
 
 import "vue-select/dist/vue-select.css";
+import cache from "../cache";
 
 export default {
   components: {
@@ -47,7 +48,7 @@ export default {
 
       let new_list = tools.clone_obj(list)
 
-      let me = JSON.parse(localStorage.profile);
+      let me = cache.getObject("profile");
       for(let i in new_list)
       {
         if(me.uuid == new_list[i].uuid)

--- a/src/gadgets/IssuesTable.vue
+++ b/src/gadgets/IssuesTable.vue
@@ -5,6 +5,7 @@ import query_parser from "../query_parser.ts";
 import d from "../dict.ts";
 import rest from "../rest";
 import tools from "../tools.ts";
+import cache from "../cache";
 
 let methods = {
   add_with_children: function (obj, arr, ch_level) {
@@ -27,11 +28,8 @@ let methods = {
     let url = "query=" + encodeURIComponent(this.search_query);
 
     this.$router.replace({});
-
-    localStorage.issues_query = this.search_query;
-    localStorage.issues_query_encoded = this.search_query_encoded;
-
-    //console.log('get issues with query ', query, localStorage.issues_query)
+    cache.setString("issues_query", this.search_query)
+    cache.setString("issues_query_encoded",  this.search_query_encoded)
     let options = {};
     this.search_query_encoded = "";
     if (query != undefined && query != "")
@@ -219,8 +217,7 @@ mod.mounted = function () {
     });
   } else {
     this.$nextTick(function () {
-      this.search_query =
-        localStorage.issues_query != undefined ? localStorage.issues_query : "";
+      this.search_query = cache.getString("issues_query")
     });
   }
 
@@ -230,9 +227,8 @@ mod.mounted = function () {
 mod.activated = function () {
   console.log("activated!");
   this.$nextTick(function () {
-    if (this.search_query == localStorage.issues_query) return;
-    this.search_query =
-      localStorage.issues_query != undefined ? localStorage.issues_query : "";
+    if (this.search_query === cache.getString("issues_query")) return;
+    this.search_query = cache.getString("issues_query")
   });
 };
 /*

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,6 +1,7 @@
 import store from "./stores/index";
 import tools from "./tools";
 import conf from "./conf";
+import cache from "./cache";
 
 export default class rest {
 
@@ -38,8 +39,8 @@ export default class rest {
     if (resp.status != 200) return null;
     const data = await resp.json();
     //rest.headers.token = data.user_token
-    localStorage.user_token = data.user_token;
-    localStorage.profile = JSON.stringify(data.profile);
+    cache.setString("user_token", data.user_token)
+    cache.setObject("profile", data.profile)
     return data;
   }
 
@@ -51,7 +52,7 @@ export default class rest {
       start: new Date(),
     };
     method = method.replace("create", "upsert").replace("update", "upsert");
-    rest.headers.set("token", localStorage.user_token);
+    rest.headers.set("token", cache.getString("user_token"));
     rest.headers.set("subdomain", rest.get_subdomain());
     //console.log('hhhh', rest.headers)
     const method_array = tools.split2(method, "_");

--- a/src/views/PageBoard.vue
+++ b/src/views/PageBoard.vue
@@ -5,6 +5,7 @@
 	import d from '../dict.ts'
 	import rest from '../rest';
 	import tools from '../tools.ts'
+  import cache from "../cache";
 
 	let methods = {
 		ws_init()
@@ -393,7 +394,7 @@
 					}
 				}
 				
-				let  stored_exp = localStorage[this.selected_board.uuid+'#'+x]
+				let stored_exp = cache.getString(this.selected_board.uuid+'#'+x)
 				if(stored_exp == undefined || stored_exp == 'false') stored_exp = false
 				else stored_exp = true
 				this.swimlanes[x].expanded = stored_exp
@@ -641,17 +642,14 @@
 			else if (p == 'Show-stopper') return 'red'
 			else return 'gray'
 		},
-		delete_board()
-		{
+		delete_board() {
 			this.$store.dispatch('delete_board')
 		},
-		swimlane_expanded_toogle(swimlane)
-		{
+		swimlane_expanded_toogle(swimlane) {
 			swimlane.expanded = !swimlane.expanded
-			localStorage[this.selected_board.uuid+'#'+swimlane.id] = swimlane.expanded
+      cache.setString(this.selected_board.uuid+'#'+swimlane.id, swimlane.expanded)
 		},
-		swimlanes_updated(v)
-		{
+		swimlanes_updated(v) {
 			if(v == null)
 			{
 				this.$store.commit('id_push_update_board' , {id: 'swimlanes_by_root', val:false})
@@ -717,15 +715,12 @@
 			}
 			return ch
 		},
-		async new_issue_card(swimlane, status)
-		{
+		async new_issue_card(swimlane, status) {
 			console.log('new issue card', swimlane, status)
-
 			let parent_uuid = swimlane.id
 			let status_uuid = status.uuid
 			let project_uuid = swimlane.project_uuid
-			let author_uuid = JSON.parse(localStorage.profile).uuid
-
+			let author_uuid = cache.getObject("profile").uuid
 			let query = decodeURIComponent(atob( this.encoded_query))
 			let search_start = 0
 			let field_start

--- a/src/views/PageIssue.vue
+++ b/src/views/PageIssue.vue
@@ -2,6 +2,7 @@
 import tools from "../tools.ts";
 import page_helper from "../page_helper.ts";
 import rest from "../rest.ts";
+import cache from "../cache";
 
 let methods = {
   pasted: async function (e) {
@@ -100,7 +101,7 @@ let methods = {
       name: action_icons[type],
       created_at: new Date(),
       value: val,
-      author: JSON.parse(localStorage.profile).name,
+      author: cache.getObject("profile").name,
     };
     console.log("New action added:", new_action);
     this.issue[0].actions.unshift(new_action);
@@ -298,8 +299,7 @@ let methods = {
     await this.update_data({ uuid: this[this.name][0].uuid });
     this.edit_mode = false;
     // this.add_action_to_history('edit', '')
-    localStorage.last_saved_issue_params = this.get_params_for_localstorage();
-    // todo save type and project in localstorage for future issue create
+    cache.setString("last_saved_issue_params", this.get_params_for_localstorage())
     this.title;
     if (this.id !== "") return;
     window.location.href = "/issue/" + this.issueProjectNum;
@@ -368,7 +368,7 @@ let methods = {
     this.get_formated_relations();
   },
   load_params_from_localstorage(storage_path, full) {
-    this.url_params = JSON.parse(localStorage[storage_path]);
+    this.url_params = cache.getObject(storage_path);
 
     console.log(
       "load params from localstore",
@@ -438,18 +438,16 @@ let methods = {
     }
 
     if (
-      (this.id == undefined || this.id == "") &&
-      this.url_params.clone == "true" &&
-      localStorage.cloned_params != undefined
+      (this.id === undefined || this.id === "") &&
+       this.url_params.clone === "true" &&
+       cache.getObject("cloned_params") !== undefined
     )
     {
-      this.url_params = JSON.parse(localStorage.cloned_params);
-
+      this.url_params = cache.getObject("cloned_params");
       this.load_params_from_localstorage("cloned_params", true);
     } 
     else if (
-      (this.id == undefined || this.id == "") &&
-      localStorage.last_saved_issue_params != undefined
+      (this.id == undefined || this.id == "") && cache.getObject("last_saved_issue_params") !== undefined
     ) 
     {
       this.load_params_from_localstorage("last_saved_issue_params");
@@ -458,16 +456,14 @@ let methods = {
     
 
     if (this.id == undefined || this.id == "") {
-      console.log("ibiiit issue", this.issue[0]);
-
+      // console.log("ibiiit issue", this.issue[0]);
       for (let i in this.issue[0].values) {
         this.issue[0].values[i].issue_uuid = this.issue[0].uuid;
         this.issue[0].values[i].uuid = tools.uuidv4();
-        if (this.issue[0].values[i].name == "Автор")
-          this.issue[0].values[i].value = JSON.parse(localStorage.profile).uuid;
+        if (this.issue[0].values[i].name === "Автор")
+          this.issue[0].values[i].value = cache.getObject("profile").uuid;
       }
-
-      console.log("ibiiit issue", this.issue[0]);
+      // console.log("ibiiit issue", this.issue[0]);
     }
 
     let ans = await rest.run_method("read_watcher", {
@@ -532,7 +528,7 @@ let methods = {
     return JSON.stringify(params);
   },
   get_clone_url: function () {
-    localStorage.cloned_params = this.get_params_for_localstorage();
+    cache.setString("cloned_params", this.get_params_for_localstorage());
     return "/issue?clone=true";
 
     let url = "/issue?t=" + new Date().getTime();

--- a/src/views/PageIssues.vue
+++ b/src/views/PageIssues.vue
@@ -5,6 +5,7 @@ import query_parser from "../query_parser.ts";
 import d from "../dict.ts";
 import rest from "../rest";
 import tools from "../tools.ts";
+import cache from "../cache";
 
 let methods = {
   add_with_children: function (obj, arr, ch_level) {
@@ -24,13 +25,9 @@ let methods = {
   },
   get_issues: async function (query, offset) {
     let url = "query=" + encodeURIComponent(this.search_query);
-
     this.$router.replace({});
-
-    localStorage.issues_query = this.search_query;
-    localStorage.issues_query_encoded = this.search_query_encoded;
-
-    //console.log('get issues with query ', query, localStorage.issues_query)
+    cache.setString("issues_query", this.search_query);
+    cache.setString("issues_query_encoded", this.search_query_encoded);
     let options = {};
     this.search_query_encoded = "";
     if (query != undefined && query != "")
@@ -262,8 +259,7 @@ mod.mounted = function () {
     });
   } else {
     this.$nextTick(function () {
-      this.search_query =
-        localStorage.issues_query != undefined ? localStorage.issues_query : "";
+      this.search_query = cache.getString("issues_query")
     });
   }
 
@@ -273,9 +269,8 @@ mod.mounted = function () {
 mod.activated = function () {
   console.log("activated!");
   this.$nextTick(function () {
-    if (this.search_query == localStorage.issues_query) return;
-    this.search_query =
-      localStorage.issues_query != undefined ? localStorage.issues_query : "";
+    if (this.search_query === cache.getString("issues_query")) return;
+    this.search_query = cache.getString("issues_query")
   });
 };
 /*

--- a/src/views/PageLogin.vue
+++ b/src/views/PageLogin.vue
@@ -23,7 +23,6 @@ login_page.methods = {
       console.log("wrong email or pass");
       this.wrong = true;
     } else {
-      //localStorage.user_token = token
       this.$router.push("/issues");
     }
   },

--- a/src/views/PageUsers.vue
+++ b/src/views/PageUsers.vue
@@ -1,6 +1,7 @@
 <script>
 import page_helper from "../page_helper.ts";
 import rest from "../rest.ts";
+import cache from "../cache.ts";
 
 const data = {
   new_pass: "",
@@ -72,7 +73,7 @@ const data = {
 const mod = await page_helper.create_module(data);
 
 mod.methods.is_this_user = function () {
-  let user = JSON.parse(localStorage.profile);
+  let user = cache.getObject("profile");
   return this.selected_users.uuid == user.uuid;
 };
 


### PR DESCRIPTION
Сделал обёртку над `localStorage`, которая при необходимости подтягивает дефолтные значения для хранимых в кэше свойств. 
- Если запрошенное свойство есть в `localStorage`, возвращает его.
- Если требуемого свойства в кэше нет, возвращается дефолтное, и оно же прописывается в кэш.
- Если дефолтного нет, возвращается `undefined`, как и в случае с прямым обращением к `localStorage`.

Добавил по 2 метода для удобства - возвращающие/сохраняющие значение либо как строку, либо как объект. Все прямые обращения к `localStorage` в проекте убрал.